### PR TITLE
Fixing talking monsters or broken voices

### DIFF
--- a/addons/ark_ai_voices/functions/fnc_selectSound.sqf
+++ b/addons/ark_ai_voices/functions/fnc_selectSound.sqf
@@ -47,7 +47,13 @@ ark_ai_voices_fnc_selectSound = {
     };
 
     _unit setVariable ["ark_ai_voices_var_lastLine", _voiceLine];
+
+    // Halloween testing, some units have "NoVoice" set
     private _speaker = speaker _unit;
+    if (_speaker in ["", "NoVoice","ACE_NoVoice"]) exitWith {
+        _unit setVariable ["ark_ai_voices_var_disableVoice", true];
+    };
+
     private _speakerVoiceLine = _speaker + _voiceLine;
     private _soundPathArr = ark_ai_voices_namespace getVariable _speakerVoiceLine;
 


### PR DESCRIPTION
Looks like some 3rd party mods use `NoVoice` so their AI doesn't talk. Catch this and mark them to be skipped in future to avoid error messages and wasted cycles.