### PR TITLE
Modules - Standardise function call

### DIFF
--- a/addons/ace_rearm/CfgVehicles.hpp
+++ b/addons/ace_rearm/CfgVehicles.hpp
@@ -3,7 +3,7 @@ class CfgVehicles {
     class ARK_ACE_Rearm: ARK_Module {
         scope = 2;
         displayName = "Inhouse - Allow rearm";
-        function = QUOTE(FUNC(enableRearm));
+        function = QFUNC(enableRearm); // Function has to be called this way otherwise it will error.
         class ModuleDescription {
             description = "Allows the synced vehicles to rearm other vehicles";
         };

--- a/addons/ai_sentry/CfgVehicles.hpp
+++ b/addons/ai_sentry/CfgVehicles.hpp
@@ -3,7 +3,7 @@ class CfgVehicles {
     class ARK_Make_Sentry: ARK_Module {
         scope = 2;
         displayName = "Inhouse - Make Sentry";
-        function = QUOTE(FUNC(makeSentry));
+        function = QFUNC(makeSentry); // Function has to be called this way otherwise it will error.
         class ModuleDescription {
             description = "Set options to make an EI sentry";
         };

--- a/addons/chase_ai/CfgVehicles.hpp
+++ b/addons/chase_ai/CfgVehicles.hpp
@@ -6,7 +6,7 @@ class CfgVehicles {
         scope = 2;
         displayName = "Chase AI - Module";
         icon = QPATHTOF(resources\chase.paa);
-        function = QUOTE(FUNC(module));
+        function = QFUNC(module); // Function has to be called this way otherwise it will error.
         isTriggerActivated = 1;
         class ModuleDescription {
             description = "Spawns AI that hunt players";

--- a/addons/clear_cargo/CfgVehicles.hpp
+++ b/addons/clear_cargo/CfgVehicles.hpp
@@ -3,7 +3,7 @@ class CfgVehicles {
     class ARK_Clear_Vehicle: ARK_Module {
         scope = 2;
         displayName = "Inhouse - Clear Vehicle Cargo";
-        function = QUOTE(FUNC(clearVehicle));
+        function = QFUNC(clearVehicle); // Function has to be called this way otherwise it will error.
         class ModuleDescription {
             description = "Clears vehicles of their default cargo";
         };

--- a/addons/deploy/CfgVehicles.hpp
+++ b/addons/deploy/CfgVehicles.hpp
@@ -3,7 +3,7 @@ class CfgVehicles {
     class ARK_Enable_Deploy: ARK_Module {
         scope = 2;
         displayName = "Inhouse - Enable Group Deploy";
-        function = QUOTE(FUNC(init));
+        function = QFUNC(init); // Function has to be called this way otherwise it will error.
         class ModuleDescription {
             description = "Enables Group Deploy";
         };

--- a/addons/main/CfgModules.hpp
+++ b/addons/main/CfgModules.hpp
@@ -6,7 +6,7 @@ class Module_F : Logic {
 class ARK_Module: Module_F {
     scope = 1;
     displayName = "ARK Module";
-    icon = "\x\ark\addons\main\resources\ark_star.paa";
+    icon = QPATHTOF(resources\ark_star.paa);
     category = "ARK";
     function = "";
     functionPriority = 1;

--- a/addons/player_paradrop/CfgVehicles.hpp
+++ b/addons/player_paradrop/CfgVehicles.hpp
@@ -3,7 +3,7 @@ class CfgVehicles {
     class ARK_Player_Paradrop: ARK_Module {
         scope = 2;
         displayName = "Inhouse - Player Paradrop";
-        function = QUOTE(FUNC(preInit));
+        function = QFUNC(preInit); // Function has to be called this way otherwise it will error.
         class ModuleDescription {
             description = "Module to enable paradrops from planes";
         };

--- a/addons/rotor/CfgVehicles.hpp
+++ b/addons/rotor/CfgVehicles.hpp
@@ -18,7 +18,7 @@ class CfgVehicles {
     class ARK_Module;
     class ARK_Rotor_Base : ARK_Module {
         scope = 1;
-        function = QUOTE(FUNC(preInit));
+        function = QFUNC(preInit); // Function has to be called this way otherwise it will error.
         isTriggerActivated = 1;
     };
 
@@ -42,9 +42,18 @@ class CfgVehicles {
                 typeName = "STRING";
                 defaultValue = "NORMAL";
                 class Values {
-                    class limited_speed {name = "Slow";  value = "LIMITED";};
-                    class normal_speed {name = "Normal"; value = "NORMAL";};
-                    class full_speed {name = "Fast"; value = "FULL";};
+                    class limited_speed {
+                        name = "Slow";
+                        value = "LIMITED";
+                    };
+                    class normal_speed {
+                        name = "Normal";
+                        value = "NORMAL";
+                    };
+                    class full_speed {
+                        name = "Fast";
+                        value = "FULL";
+                    };
                 };
             };
             class Crew_Percentage {
@@ -53,10 +62,22 @@ class CfgVehicles {
                 typeName = "NUMBER";
                 defaultValue = 50;
                 class Values {
-                    class twenty_five {name = "25%"; value = 25;};
-                    class fifty {name = "50%"; value = 50;};
-                    class seventy_five {name = "75%"; value = 75;};
-                    class one_hundred {name = "100%"; value = 100;};
+                    class twenty_five {
+                        name = "25%";
+                        value = 25;
+                    };
+                    class fifty {
+                        name = "50%";
+                        value = 50;
+                    };
+                    class seventy_five {
+                        name = "75%";
+                        value = 75;
+                    };
+                    class one_hundred {
+                        name = "100%";
+                        value = 100;
+                    };
                 };
             };
             class Vehicle_ClassName {
@@ -69,7 +90,7 @@ class CfgVehicles {
                 displayName = "Routine Function";
                 description = "The function called by this module. Do not change this unless you know what it does";
                 typeName = "STRING";
-                defaultValue = QUOTE(call FUNC(paradrop));
+                defaultValue = QFUNC(paradrop);
             };
         };
     };
@@ -94,9 +115,18 @@ class CfgVehicles {
                 typeName = "STRING";
                 defaultValue = "NORMAL";
                 class Values {
-                    class limited_speed {name = "Slow";  value = "LIMITED";};
-                    class normal_speed {name = "Normal"; value = "NORMAL";};
-                    class full_speed {name = "Fast"; value = "FULL";};
+                    class limited_speed {
+                        name = "Slow";
+                        value = "LIMITED";
+                    };
+                    class normal_speed {
+                        name = "Normal";
+                        value = "NORMAL";
+                    };
+                    class full_speed {
+                        name = "Fast";
+                        value = "FULL";
+                    };
                 };
             };
             class Crew_Percentage {
@@ -105,10 +135,22 @@ class CfgVehicles {
                 typeName = "NUMBER";
                 defaultValue = 50;
                 class Values {
-                    class twenty_five {name = "25%"; value = 25;};
-                    class fifty {name = "50%"; value = 50;};
-                    class seventy_five {name = "75%"; value = 75;};
-                    class one_hundred {name = "100%"; value = 100;};
+                    class twenty_five {
+                        name = "25%";
+                        value = 25;
+                    };
+                    class fifty {
+                        name = "50%";
+                        value = 50;
+                    };
+                    class seventy_five {
+                        name = "75%";
+                        value = 75;
+                    };
+                    class one_hundred {
+                        name = "100%";
+                        value = 100;
+                    };
                 };
             };
             class Vehicle_ClassName {
@@ -121,7 +163,7 @@ class CfgVehicles {
                 displayName = "Routine Function";
                 description = "The function called by this module. Do not change this unless you know what it does";
                 typeName = "STRING";
-                defaultValue = QUOTE(call FUNC(insert));
+                defaultValue = QFUNC(insert);
             };
         };
     };
@@ -146,9 +188,18 @@ class CfgVehicles {
                 typeName = "STRING";
                 defaultValue = "NORMAL";
                 class Values {
-                    class limited_speed {name = "Slow";  value = "LIMITED";};
-                    class normal_speed {name = "Normal"; value = "NORMAL";};
-                    class full_speed {name = "Fast"; value = "FULL";};
+                    class limited_speed {
+                        name = "Slow";
+                        value = "LIMITED";
+                    };
+                    class normal_speed {
+                        name = "Normal";
+                        value = "NORMAL";
+                    };
+                    class full_speed {
+                        name = "Fast";
+                        value = "FULL";
+                    };
                 };
             };
             class Bomb_Amount {
@@ -157,11 +208,26 @@ class CfgVehicles {
                 typeName = "NUMBER";
                 defaultValue = 3;
                 class Values {
-                    class one_barrel {name = "One";  value = 1;};
-                    class two_barrel {name = "Two";  value = 2;};
-                    class three_barrel {name = "Three";  value = 3;};
-                    class four_barrel {name = "Four";  value = 4;};
-                    class five_barrel {name = "Five";  value = 5;};
+                    class one_barrel {
+                        name = "One";
+                        value = 1;
+                    };
+                    class two_barrel {
+                        name = "Two";
+                        value = 2;
+                    };
+                    class three_barrel {
+                        name = "Three";
+                        value = 3;
+                    };
+                    class four_barrel {
+                        name = "Four";
+                        value = 4;
+                    };
+                    class five_barrel {
+                        name = "Five";
+                        value = 5;
+                    };
                 };
             };
             class Vehicle_ClassName {
@@ -174,7 +240,7 @@ class CfgVehicles {
                 displayName = "Routine Function";
                 description = "The function called by this module. Do not change this unless you know what it does";
                 typeName = "STRING";
-                defaultValue = QUOTE(call FUNC(barrelbomb));
+                defaultValue = QFUNC(barrelbomb);
             };
         };
     };


### PR DESCRIPTION
- All modules initial `function` parameter should be `QFUNC(XYZ);` otherwise the entire module fails in a really annoying way.
- Same with any function in `defaultValue`
- I tested Barrel Bomb & Paradrop with this setup and it seems to be working just fine.