### PR TITLE
All - Utilise alternative syntax of createGroup

### DIFF
--- a/addons/admin_tools/functions/fnc_callReinforcements.sqf
+++ b/addons/admin_tools/functions/fnc_callReinforcements.sqf
@@ -44,8 +44,7 @@ if (_roadObj isNotEqualTo objNull) then {
     _vehicle setDir ((_roadInfo #6) getDir (_roadInfo #7));
 };
 
-private _group = createGroup _side;
-_group deleteGroupWhenEmpty true;
+private _group = createGroup [_side, true];
 
 private _driver = [[0,0,0], _group, _crewClasses, _skillArray] call adm_common_fnc_placeMan;
 _driver assignAsDriver _vehicle;

--- a/addons/admiral/camp_functions.sqf
+++ b/addons/admiral/camp_functions.sqf
@@ -147,8 +147,7 @@ adm_camp_fnc_spawnInfGroup = {
     private _unitTemplate = GET_ZONE_UNIT_TEMPLATE(_zone);
     private _zoneTemplate = GET_ZONE_TEMPLATE(_zone);
     private _initialPos = [GET_ZONE_AREA(_zone), GET_ZONE_POSITION(_zone), "SoldierWB"] call adm_common_fnc_getRandomEmptyPositionInArea;
-    private _group = createGroup ([_unitTemplate] call adm_common_fnc_getUnitTemplateSide);
-    _group deleteGroupWhenEmpty true;
+    private _group = createGroup [([_unitTemplate] call adm_common_fnc_getUnitTemplateSide), true];
     private _groupSize = ["ZoneTemplates", _zoneTemplate, "infFireteamSize"] call adm_config_fnc_getNumber;
     for "_i" from 1 to _groupSize do {
         private _position = _initialPos findEmptyPosition [1, CAMP_SPAWN_CIRCLE_MAX_DIST, "SoldierWB"];
@@ -173,9 +172,8 @@ adm_camp_fnc_spawnVehicleGroup = {
     private _vehicle = [[_unitTemplate, GROUP_TYPE_ARRAY select _groupType] call adm_common_fnc_getUnitTemplateArray, GET_ZONE_AREA(_zone), GET_ZONE_POSITION(_zone)] call adm_common_fnc_placeVehicle;
     [format ["%1.spawned.vehicle", GET_ZONE_TYPE(_zone)], [_vehicle, GROUP_TYPE_ARRAY select _groupType, _zone]] call adm_event_fnc_emitEvent;
     ["zone.spawned.vehicle", [_vehicle, GROUP_TYPE_ARRAY select _groupType, _zone]] call adm_event_fnc_emitEvent;
-    private _group = createGroup ([_unitTemplate] call adm_common_fnc_getUnitTemplateSide);
+    private _group = createGroup [([_unitTemplate] call adm_common_fnc_getUnitTemplateSide), true];
     _group setVariable ["adm_group_type", _groupType, false];
-    _group deleteGroupWhenEmpty true;
     private _crew = [_vehicle, _group, _unitTemplate, _zoneTemplate, UNIT_TYPE_ARRAY select _unitType] call adm_camp_fnc_spawnCrew;
     [format ["%1.spawned.crew", GET_ZONE_TYPE(_zone)], [_crew, UNIT_TYPE_ARRAY select _unitType, GROUP_TYPE_ARRAY select _groupType, _zone]] call adm_event_fnc_emitEvent;
     ["zone.spawned.crew", [_crew, UNIT_TYPE_ARRAY select _unitType, GROUP_TYPE_ARRAY select _groupType, _zone]] call adm_event_fnc_emitEvent;

--- a/addons/admiral/cqc_functions.sqf
+++ b/addons/admiral/cqc_functions.sqf
@@ -123,10 +123,9 @@ adm_cqc_fnc_spawnGarrisonGroup = {
     params ["_zone","_numOfUnits","_possiblePositions","_building"];
 
     private _unitTemplate = GET_ZONE_UNIT_TEMPLATE(_zone);
-    private _group = createGroup ([_unitTemplate] call adm_common_fnc_getUnitTemplateSide);
+    private _group = createGroup [([_unitTemplate] call adm_common_fnc_getUnitTemplateSide), true];
     [_group, _numOfUnits, _unitTemplate, GET_ZONE_TEMPLATE(_zone), _possiblePositions, _building, _zone] call adm_cqc_fnc_spawnGarrisonGroupUnits;
     _group setVariable ["adm_zone_parent", _zone];
-    _group deleteGroupWhenEmpty true;
     _group enableDynamicSimulation adm_cqc_dynamicSimEnabled;
 
     _group;

--- a/addons/chase_ai/functions/fnc_createGroup.sqf
+++ b/addons/chase_ai/functions/fnc_createGroup.sqf
@@ -14,8 +14,7 @@
  */
 
 if (isNil "ark_chase_ai_grp" || {ark_chase_ai_grp isEqualTo grpNull}) then {
-    ark_chase_ai_grp = createGroup ark_chase_ai_var_side;
-    ark_chase_ai_grp deleteGroupWhenEmpty true;
+    ark_chase_ai_grp = createGroup [ark_chase_ai_var_side, true];
     ark_chase_ai_grp enableAttack false;
     ark_chase_ai_grp setCombatMode "RED";
 };

--- a/addons/rotor/functions/fnc_createCargo.sqf
+++ b/addons/rotor/functions/fnc_createCargo.sqf
@@ -22,8 +22,7 @@ params ["_cargoClassnames", "_side", "_vehicle", "_parachute", "_logic"];
 private _skillArray = ["Camp"] call adm_common_fnc_getZoneTemplateSkillValues;
 private _emptySeats = count (fullCrew [_vehicle, "", true] - fullCrew [_vehicle, "driver"]);
 private _adjSeats = floor ((_logic getVariable ["Crew_Percentage", 50])/100 * _emptySeats);
-private _grp = createGroup _side;
-_grp deleteGroupWhenEmpty true;
+private _grp = createGroup [_side, true];
 
 [{
     params ["_args", "_id"];

--- a/addons/rotor/functions/fnc_createPilot.sqf
+++ b/addons/rotor/functions/fnc_createPilot.sqf
@@ -18,8 +18,7 @@
 params ["_pilotClassnames", "_side", "_vehicle"];
 
 private _skillArray = ["Vehicles"] call adm_common_fnc_getZoneTemplateSkillValues;
-private _grp = createGroup _side;
-_grp deleteGroupWhenEmpty true;
+private _grp = createGroup [_side, true];
 private _pilot = [[0,0,0], _grp, _pilotClassnames, _skillArray] call adm_common_fnc_placeMan;
 _pilot assignAsDriver _vehicle;
 _pilot moveInDriver _vehicle;

--- a/addons/town_sweep/functions/fnc_enableRotor.sqf
+++ b/addons/town_sweep/functions/fnc_enableRotor.sqf
@@ -22,8 +22,7 @@ if (count _selectedPos isEqualTo 3) exitWith {};
 
 private _spawnPos = _position getPos [3000, random 360];
 private _spawnZone = createTrigger ["EmptyDetector", _spawnPos, false];
-private _grp = createGroup civilian;
-_grp deleteGroupWhenEmpty true;
+private _grp = createGroup [civilian, true];
 
 private _jeff = _grp createUnit ["C_Jeff_VR", _spawnPos, [], 0, "NONE"];
 _grp addWaypoint [_lzPos, 0, 1];

--- a/addons/town_sweep/functions/fnc_fillFortifications.sqf
+++ b/addons/town_sweep/functions/fnc_fillFortifications.sqf
@@ -26,8 +26,7 @@ if (count _buildingPositions < 6) then {
     };
 };
 
-private _grp = createGroup ts_enemy_side;
-_grp deleteGroupWhenEmpty true;
+private _grp = createGroup [ts_enemy_side, true];
 _grp enableDynamicSimulation true;
 
 private _skillArray = ["Cqc"] call adm_common_fnc_getZoneTemplateSkillValues;

--- a/addons/town_sweep/functions/fnc_objDestroyVeh.sqf
+++ b/addons/town_sweep/functions/fnc_objDestroyVeh.sqf
@@ -15,8 +15,7 @@
 
 ts_spawn_selectedLocation params ["_position","_size"];
 
-private _grp = createGroup ts_enemy_side;
-_grp deleteGroupWhenEmpty true;
+private _grp = createGroup [ts_enemy_side, true];
 _grp enableDynamicSimulation true;
 private _skillArray = ["Vehicles"] call adm_common_fnc_getZoneTemplateSkillValues;
 private _crewmanClassnames = [adm_camp_defaultUnitTemplate, "crewmen"] call adm_common_fnc_getUnitTemplateArray;


### PR DESCRIPTION
- Alt syntax for `createGroup` can automatically include `deleteGroupWhenEmpty`
- Minor optimisation but still, may aswell.